### PR TITLE
Persist POS product form state and harden numeric inputs

### DIFF
--- a/src/Components/CatalogoWeb/Context/AppContext.tsx
+++ b/src/Components/CatalogoWeb/Context/AppContext.tsx
@@ -10,6 +10,7 @@ import { Customer } from "../PuntoVenta/Model/Customer";
 import { FilterProduct } from "../PuntoVenta/Model/FilterProduct";
 import { Table } from "../PuntoVenta/Model/Table";
 import { CartPos } from "../PuntoVenta/Model/CarPos";
+import { ProductFormState } from "../PuntoVenta/Model/ProductFormState";
 
 type AppContextProps = {
   children: React.ReactNode;
@@ -60,6 +61,7 @@ const AppProvider: React.FC<AppContextProps> = ({ children }) => {
   const [tax, setTax] = useState<Tax>({} as Tax);
   const [checkout, setCheckout] = useState<boolean>(false);
   const [showNavBarBottom, setShowNavBarBottom] = useState<boolean>(false);
+  const [productFormState, setProductFormState] = useState<ProductFormState | null>(null);
 
     // Función para actualizar una mesa
     const updateTable = (tableId: string, updates: Partial<Table>) => {
@@ -182,7 +184,9 @@ const AppProvider: React.FC<AppContextProps> = ({ children }) => {
       resetTable,
       addTable,
       showNavBarBottom,
-      setShowNavBarBottom
+      setShowNavBarBottom,
+      productFormState,
+      setProductFormState,
     };
   }, [
     cart,
@@ -238,7 +242,9 @@ const AppProvider: React.FC<AppContextProps> = ({ children }) => {
     resetTable,
     addTable,
     showNavBarBottom,
-    setShowNavBarBottom
+    setShowNavBarBottom,
+    productFormState,
+    setProductFormState
   ]);
 
   return <AppContext.Provider value={value}>{children}</AppContext.Provider>;

--- a/src/Components/CatalogoWeb/Context/EstadoContexto.tsx
+++ b/src/Components/CatalogoWeb/Context/EstadoContexto.tsx
@@ -1,4 +1,4 @@
-import { Dispatch,SetStateAction } from "react";
+import { Dispatch, SetStateAction } from "react";
 import { Producto } from "../Modelo/Producto";
 //apartir de aqui son las variables para el contexto de ravekh pos web
 import { User } from "../PuntoVenta/Model/User";
@@ -10,6 +10,7 @@ import { Category } from "../PuntoVenta/Model/Category";
 import { Store } from "../PuntoVenta/Model/Store";
 import { Table } from "../PuntoVenta/Model/Table";
 import { Tax } from "../PuntoVenta/Model/Tax";
+import { ProductFormState } from "../PuntoVenta/Model/ProductFormState";
 export type AppContextState = {
     cart: Producto[];
     setCart: Dispatch<Producto[]>;
@@ -67,4 +68,6 @@ export type AppContextState = {
     setCaptureUri: Dispatch<SetStateAction<string | null>>;
     showNavBarBottom: boolean;
     setShowNavBarBottom: Dispatch<SetStateAction<boolean>>;
+    productFormState: ProductFormState | null;
+    setProductFormState: Dispatch<SetStateAction<ProductFormState | null>>;
 }

--- a/src/Components/CatalogoWeb/PuntoVenta/Model/ProductFormState.ts
+++ b/src/Components/CatalogoWeb/PuntoVenta/Model/ProductFormState.ts
@@ -1,0 +1,20 @@
+export type ProductFormMode = "add" | "edit";
+
+export interface ProductFormState {
+  mode: ProductFormMode;
+  productId?: number;
+  productName: string;
+  price: string;
+  cost: string;
+  barcode: string;
+  stock: string;
+  minStock: string;
+  optStock: string;
+  promoPrice: string;
+  description: string;
+  unitType: string;
+  colorSelected: string;
+  image: string | null;
+  isAvailableForSale: boolean;
+  isDisplayedInStore: boolean;
+}


### PR DESCRIPTION
## Summary
- add a reusable product form state in the app context so the add and edit product flows keep entered data when switching routes
- update the add and edit product screens to restore/sync the draft form, restrict inventory numeric inputs, and prevent duplicate submissions while saving
- introduce a shared model definition for the persisted product form state

## Testing
- npm run build *(fails: existing CSS import order causes Vite to abort)*

------
https://chatgpt.com/codex/tasks/task_e_690d0147452083249bc6e400913e8399