### PR TITLE
Add change-name screen for coupons settings

### DIFF
--- a/src/Components/Cupones/CuponesChangeName.tsx
+++ b/src/Components/Cupones/CuponesChangeName.tsx
@@ -1,0 +1,90 @@
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import cubito from "../../assets/Cupones/cubito.png";
+import { hasCuponesSession } from "./cuponesSession";
+
+const accentYellow = "#ffca1f";
+const textGray = "#414141";
+const inputGray = "#e6e6e6";
+
+const BackIcon: React.FC = () => (
+  <svg
+    viewBox="0 0 24 24"
+    className="h-6 w-6"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M15 18l-6-6 6-6" />
+  </svg>
+);
+
+const CuponesChangeName: React.FC = () => {
+  const navigate = useNavigate();
+  const [fullName, setFullName] = useState("");
+
+  useEffect(() => {
+    if (!hasCuponesSession()) {
+      navigate("/cupones", { replace: true });
+    }
+  }, [navigate]);
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    // Aquí se podría agregar la lógica para actualizar el nombre
+  };
+
+  return (
+    <div className="min-h-screen bg-white relative overflow-hidden flex justify-center px-6 pb-12">
+      <div className="absolute top-[-140px] right-[-160px] w-[320px] h-[320px] bg-[#ffca1f] rounded-full opacity-70" />
+      <div className="absolute bottom-[-160px] left-[-200px] w-[360px] h-[360px] bg-[#ffca1f] rounded-full opacity-70" />
+
+      <div className="relative w-full max-w-[460px] z-10">
+        <div className="pt-6">
+          <button
+            type="button"
+            onClick={() => navigate(-1)}
+            className="h-12 w-12 rounded-lg bg-[#f2f2f2] flex items-center justify-center shadow-sm text-[#6a6a6a]"
+            aria-label="Volver"
+          >
+            <BackIcon />
+          </button>
+        </div>
+
+        <div className="mt-6 flex justify-center">
+          <img src={cubito} alt="Mascota Cupones" className="h-40 w-40 object-contain" />
+        </div>
+
+        <section className="mt-8 text-center text-[#414141]" style={{ color: textGray }}>
+          <h1 className="text-xl font-extrabold">Aquí puedes cambiar tu nombre</h1>
+        </section>
+
+        <form className="mt-6 space-y-5" onSubmit={handleSubmit}>
+          <div>
+            <input
+              type="text"
+              value={fullName}
+              onChange={(event) => setFullName(event.target.value)}
+              placeholder="Nombre completo"
+              className="w-full rounded-xl px-4 py-3 text-base shadow-inner outline-none"
+              style={{ backgroundColor: inputGray, color: textGray }}
+            />
+          </div>
+
+          <button
+            type="submit"
+            className="w-full rounded-full px-4 py-3 text-lg font-extrabold text-white shadow-[0_12px_22px_rgba(251,188,4,0.45)]"
+            style={{ backgroundColor: accentYellow }}
+          >
+            Actualizar información
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export { CuponesChangeName };
+export default CuponesChangeName;

--- a/src/Components/Cupones/CuponesHome.tsx
+++ b/src/Components/Cupones/CuponesHome.tsx
@@ -88,6 +88,7 @@ const CuponesHome: React.FC = () => {
               type="button"
               className="flex flex-col items-center justify-center rounded-xl px-2 py-3 shadow-[0_10px_20px_rgba(0,0,0,0.14)]"
               style={{ backgroundColor: mutedRose, color: textDark }}
+              onClick={() => navigate("/cupones/visitas")}
             >
               <img src={cuponsito} alt="Mis visitas" className="h-12 w-12 object-contain" />
               <span className="mt-2 font-bold text-sm">Mis visitas</span>
@@ -96,6 +97,7 @@ const CuponesHome: React.FC = () => {
               type="button"
               className="flex flex-col items-center justify-center rounded-xl px-2 py-3 shadow-[0_10px_20px_rgba(0,0,0,0.14)]"
               style={{ backgroundColor: mutedRose, color: textDark }}
+              onClick={() => navigate("/cupones/cupones")}
             >
               <img src={cuponsito} alt="Mis cupones" className="h-12 w-12 object-contain" />
               <span className="mt-2 font-bold text-sm">Mis cupones</span>

--- a/src/Components/Cupones/CuponesSettings.tsx
+++ b/src/Components/Cupones/CuponesSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import cuponsito from "../../assets/Cupones/cuponsito.png";
 import { CuponesNav } from "./CuponesNav";
@@ -8,8 +8,18 @@ const accentYellow = "#fbbc04";
 const textGray = "#414141";
 const buttonGray = "#e3e3e3";
 const arrowGray = "#5a5a5a";
+const accentRed = "#c0202b";
 
-const options = ["Cambiar nombre", "Eliminar cuenta"];
+const options = [
+  {
+    label: "Cambiar nombre",
+    action: "change-name",
+  },
+  {
+    label: "Eliminar cuenta",
+    action: "delete-account",
+  },
+];
 
 const ArrowIcon: React.FC = () => (
   <svg
@@ -27,12 +37,25 @@ const ArrowIcon: React.FC = () => (
 
 const CuponesSettings: React.FC = () => {
   const navigate = useNavigate();
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
 
   useEffect(() => {
     if (!hasCuponesSession()) {
       navigate("/cupones", { replace: true });
     }
   }, [navigate]);
+
+  const handleOptionClick = (action: string) => {
+    if (action === "change-name") {
+      navigate("/cupones/cambiar-nombre");
+    }
+
+    if (action === "delete-account") {
+      setShowDeleteModal(true);
+    }
+  };
+
+  const closeModal = () => setShowDeleteModal(false);
 
   return (
     <div className="min-h-screen bg-white relative overflow-hidden flex justify-center px-4 pb-12">
@@ -51,14 +74,15 @@ const CuponesSettings: React.FC = () => {
         </header>
 
         <main className="mt-10 space-y-3">
-          {options.map((label) => (
+          {options.map((option) => (
             <button
-              key={label}
+              key={option.label}
               type="button"
               className="w-full flex items-center justify-between px-4 py-3 rounded-2xl text-base font-semibold shadow-[0_10px_24px_rgba(0,0,0,0.08)]"
               style={{ backgroundColor: buttonGray, color: textGray }}
+              onClick={() => handleOptionClick(option.action)}
             >
-              <span>{label}</span>
+              <span>{option.label}</span>
               <span className="text-xl" style={{ color: arrowGray }}>
                 <ArrowIcon />
               </span>
@@ -70,6 +94,47 @@ const CuponesSettings: React.FC = () => {
           <CuponesNav active="ajustes" />
         </div>
       </div>
+
+      {showDeleteModal && (
+        <div className="fixed inset-0 z-50 flex items-end justify-center px-4 pb-6">
+          <div
+            className="absolute inset-0 bg-black/40"
+            aria-hidden="true"
+            onClick={closeModal}
+          />
+          <div
+            className="relative w-full max-w-[480px] rounded-3xl shadow-[0_18px_38px_rgba(0,0,0,0.24)]"
+            style={{ backgroundColor: accentYellow }}
+            role="dialog"
+            aria-modal="true"
+            aria-label="Confirmar eliminación"
+          >
+            <div className="px-6 pt-6 pb-8 text-center space-y-6">
+              <p className="text-white text-base font-semibold">
+                Esta acción es irreversible, ¿estás seguro?
+              </p>
+
+              <div className="space-y-3">
+                <button
+                  type="button"
+                  className="w-full rounded-full py-3 text-white text-lg font-extrabold shadow-[0_12px_20px_rgba(192,32,43,0.35)]"
+                  style={{ backgroundColor: accentRed }}
+                >
+                  Eliminar
+                </button>
+                <button
+                  type="button"
+                  onClick={closeModal}
+                  className="w-full rounded-full py-3 text-lg font-extrabold"
+                  style={{ color: "#ffffff", backgroundColor: "transparent" }}
+                >
+                  Cancelar
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/Components/Cupones/CuponesVisits.tsx
+++ b/src/Components/Cupones/CuponesVisits.tsx
@@ -1,0 +1,82 @@
+import React, { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import cubito from "../../assets/Cupones/cubito.png";
+import { hasCuponesSession } from "./cuponesSession";
+
+const accentYellow = "#ffca1f";
+const textGray = "#414141";
+const cardGray = "#e6e6e6";
+const accentRed = "#c0202b";
+
+const visits = new Array(6).fill("12 de agosto de 2025 6:50pm");
+
+const BackIcon: React.FC = () => (
+  <svg
+    viewBox="0 0 24 24"
+    className="h-6 w-6"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2.4"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M15 18l-6-6 6-6" />
+  </svg>
+);
+
+const CuponesVisits: React.FC = () => {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!hasCuponesSession()) {
+      navigate("/cupones", { replace: true });
+    }
+  }, [navigate]);
+
+  return (
+    <div className="min-h-screen bg-white relative overflow-hidden flex justify-center px-4 pb-12">
+      <div className="absolute top-[-120px] right-[-180px] w-[340px] h-[340px] bg-[#ffca1f] rounded-full opacity-70" />
+      <div className="absolute bottom-[-180px] left-[-200px] w-[420px] h-[420px] bg-[#ffca1f] rounded-full opacity-70" />
+
+      <div className="relative w-full max-w-[460px] z-10">
+        <header className="flex items-center gap-3 pt-8 pb-2">
+          <button
+            type="button"
+            onClick={() => navigate(-1)}
+            className="h-12 w-12 rounded-xl flex items-center justify-center text-white shadow-md"
+            style={{ backgroundColor: accentRed }}
+            aria-label="Volver"
+          >
+            <BackIcon />
+          </button>
+          <h1 className="text-xl font-extrabold" style={{ color: textGray }}>
+            Mis visitas
+          </h1>
+          <div className="ml-auto">
+            <img src={cubito} alt="Mascota Cupones" className="h-12 w-12 object-contain" />
+          </div>
+        </header>
+
+        <div className="mt-2 rounded-2xl overflow-hidden shadow-[0_10px_28px_rgba(0,0,0,0.08)]">
+          <div className="h-10" style={{ backgroundColor: accentYellow }} />
+          <div className="bg-white px-4 pb-6">
+            <div className="mt-[-24px] space-y-3">
+              {visits.map((visit, index) => (
+                <div
+                  key={`${visit}-${index}`}
+                  className="w-full rounded-xl px-4 py-3 text-sm font-semibold shadow-[0_8px_12px_rgba(0,0,0,0.12)]"
+                  style={{ backgroundColor: cardGray, color: textGray }}
+                >
+                  {visit}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export { CuponesVisits };
+export default CuponesVisits;

--- a/src/Components/Rutas/Rutas.jsx
+++ b/src/Components/Rutas/Rutas.jsx
@@ -128,6 +128,8 @@ import { RegisterCupones } from "../Cupones/RegisterCupones";
 import { CuponesHome } from "../Cupones/CuponesHome";
 import { CuponesList } from "../Cupones/CuponesList";
 import { CuponesSettings } from "../Cupones/CuponesSettings";
+import { CuponesChangeName } from "../Cupones/CuponesChangeName";
+import { CuponesVisits } from "../Cupones/CuponesVisits";
 
 export const Rutas = () => {
   const navigate = useNavigate(); // Hook de react-router-dom para navegar entre rutas
@@ -819,6 +821,8 @@ export const Rutas = () => {
           <Route path="/cupones/home" element={<CuponesHome />} />
           <Route path="/cupones/cupones" element={<CuponesList />} />
           <Route path="/cupones/ajustes" element={<CuponesSettings />} />
+          <Route path="/cupones/cambiar-nombre" element={<CuponesChangeName />} />
+          <Route path="/cupones/visitas" element={<CuponesVisits />} />
           {/* RUTAS PARA EL PUNTO DE VENTA */}
           <Route path="/login-punto-venta" element={<AuthPage />} />
           <Route path="/MainSales" element={<MainSales />} />


### PR DESCRIPTION
## Summary
- add dedicated change-name screen for coupons with updated styling and form
- wire the settings menu to navigate to the new screen and register the route
- add delete-account confirmation modal matching coupons color palette
- add visits listing screen and hook home shortcuts to visits and coupons list

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942e563d3048324a2089978a75b55da)