### PR TITLE
Sync coupons session and support post-login redirects for POS; redirect coupon-web to POS login

### DIFF
--- a/src/Components/CatalogoWeb/PuntoVenta/Login/AuthPage.tsx
+++ b/src/Components/CatalogoWeb/PuntoVenta/Login/AuthPage.tsx
@@ -1,10 +1,11 @@
-import React, { useContext, useEffect, useState, useRef } from "react";
+import React, { useCallback, useContext, useEffect, useRef, useState } from "react";
 import "./Login.css";
 //import { GoogleLogin, CredentialResponse } from "@react-oauth/google";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { loginToServer, signUpToServer } from "./Peticiones";
 import { jwtDecode } from "jwt-decode";
 import { AppContext } from "../../Context/AppContext";
+import { persistCuponesAuthSession } from "../../../../coupons/services/authSession";
 interface DecodedToken {
   name: string;
   email: string;
@@ -13,6 +14,29 @@ interface DecodedToken {
 export const AuthPage: React.FC = () => {
   const context = useContext(AppContext);
   const navigate = useNavigate();
+  const location = useLocation();
+  const redirectTo = (location.state as { redirectTo?: string } | null)?.redirectTo;
+
+  const navigateAfterAuth = useCallback(() => {
+    if (typeof redirectTo === "string" && redirectTo.startsWith("/")) {
+      navigate(redirectTo, { replace: true });
+      return;
+    }
+
+    navigate("/MainSales");
+  }, [navigate, redirectTo]);
+
+  const syncCouponsSession = (payload: unknown) => {
+    if (!payload || typeof payload !== "object") {
+      return;
+    }
+
+    try {
+      persistCuponesAuthSession(payload as Record<string, unknown>);
+    } catch (_error) {
+      // El login POS puede no incluir todos los campos esperados por cupones.
+    }
+  };
   // variables para el control del login y errores
   const [errorUsuario, setErrorUsuario] = useState("");
   const [errorPassword, setErrorPassword] = useState("");
@@ -110,7 +134,8 @@ export const AuthPage: React.FC = () => {
       localStorage.setItem("user", JSON.stringify({ email, password }));
       context.setUser(dataLogin);
       context.setShowNavBarBottom(true);
-      navigate("/MainSales");
+      syncCouponsSession(dataLogin);
+      navigateAfterAuth();
     
     }
   };
@@ -152,11 +177,12 @@ export const AuthPage: React.FC = () => {
         } else {
           context.setUser(data);
           context.setShowNavBarBottom(true);
-          navigate("/MainSales");
+          syncCouponsSession(data);
+          navigateAfterAuth();
         }
       });
     }
-  }, []);
+  }, [context, navigateAfterAuth]);
   return (
     <div className="w-full h-screen flex justify-center items-center">
       <div className="container" id="container" ref={containerRef}>

--- a/src/coupons/pages/CouponWebRedeemPage.tsx
+++ b/src/coupons/pages/CouponWebRedeemPage.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import cuponsito from "../../assets/Cupones/cuponsito.png";
-import { CuponesNav } from "../interface/CouponsNav";
 import { useCouponsTheme } from "../interface/useCouponsTheme";
 import { redeemCouponByUser } from "../services/couponsApi";
 import { getCuponesRole, getCuponesUserName, hasCuponesSession } from "../services/session";
@@ -23,7 +22,10 @@ const CouponWebRedeemPage: React.FC = () => {
 
   useEffect(() => {
     if (!hasCuponesSession()) {
-      navigate("/cupones", { replace: true, state: { redirectTo: window.location.pathname + window.location.search } });
+      navigate("/login-punto-venta", {
+        replace: true,
+        state: { redirectTo: window.location.pathname + window.location.search }
+      });
       return;
     }
 
@@ -127,8 +129,6 @@ const CouponWebRedeemPage: React.FC = () => {
             </p>
           </section>
         </main>
-
-        <CuponesNav active="cupones" />
       </div>
     </div>
   );


### PR DESCRIPTION
### Motivation
- Ensure the POS login flow can persist coupons authentication state so the coupons subsystem recognizes the logged user. 
- Allow web flows (QR coupon redeem) to redirect users to the POS login and return them to the original URL after successful authentication. 
- Clean up unused coupon navigation import and prevent unconditional navigation to `/MainSales` so redirects are respected.

### Description
- In `AuthPage.tsx` add `useLocation` and import `persistCuponesAuthSession`, extract `redirectTo` from location state and add `navigateAfterAuth` to centralize post-login navigation logic. 
- Add `syncCouponsSession` which calls `persistCuponesAuthSession` with a guarded payload and is invoked on successful login and on auto-login from `localStorage`. 
- Replace direct `navigate("/MainSales")` calls with `navigateAfterAuth()` and add the appropriate effect dependencies. 
- In `CouponWebRedeemPage.tsx` change the unauthenticated redirect to navigate to `/login-punto-venta` and pass the current path+query via `state: { redirectTo: ... }`. 
- Remove an unused `CuponesNav` import and its render output at the bottom of the redeem page.

### Testing
- Ran the project type check with `tsc` and the TypeScript build, which succeeded. 
- Ran the test suite with `yarn test` (existing unit tests and CI checks), which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5ba03c9008324a36624abc18bec0d)