### PR TITLE
feat(pos-v2): implement real products feature with modern routing and tests

### DIFF
--- a/docs/pos-v2-products-iteration.md
+++ b/docs/pos-v2-products-iteration.md
@@ -1,0 +1,57 @@
+# POS v2 Products Iteration (Incremental Modernization)
+
+## Decisiones técnicas
+
+- Se implementó una feature real de `products` en arquitectura moderna (`API -> Service -> Page -> React Screen`) bajo `src/new/systems/pos/features/products/**`.
+- Se agregó una feature auxiliar `health` para validar disponibilidad API desde `/v2/pos/health`.
+- Se incorporó entrypoint `/pos` con toggle de ruteo `legacy|modern` persistido en `localStorage`.
+- El modo `legacy` redirige a `/MainSales`; el modo `modern` redirige a `/v2/pos/products`.
+- La UI v2 de productos permite listar, crear y archivar productos reales contra API POS.
+
+## Mapa de rutas (legacy vs v2)
+
+### Legacy (sin cambios)
+
+- `/MainSales`
+- `/main-products/*`
+- `/main-reports`
+- `/more`
+- `/dashboard`
+- `/MainFinances`
+- `/clients`
+- `/employees`
+
+### Entrada unificada POS
+
+- `/pos` (respeta toggle de modo)
+  - `/pos?mode=legacy`
+  - `/pos?mode=modern`
+
+### V2 POS
+
+- `/v2/pos` (default a products)
+- `/v2/pos/products`
+- `/v2/pos/health`
+
+## Checklist de independencia legacy
+
+- [x] No se importó `src/Components/**` dentro de `src/new/**` nuevo.
+- [x] No se reutilizó lógica legacy por import directo en la nueva feature.
+- [x] La nueva ruta `/v2/pos/products` usa sólo capas modernas.
+- [x] Rutas legacy existentes permanecen operativas.
+- [x] Se agregaron pruebas unitarias, de integración y de desacoplamiento.
+
+## Rollback
+
+1. Forzar temporalmente `/pos?mode=legacy` en navegación principal.
+2. Eliminar rutas `/v2/pos/*` del catálogo si hay incidente.
+3. Mantener backend y contratos sin cambios (rollback front-only).
+4. Revertir commit de esta iteración para regresar a estado anterior.
+
+## Definición de Done
+
+- [x] Feature real de products v2 expuesta bajo `/v2/pos/products`.
+- [x] API, service y page conectados con flujo end-to-end.
+- [x] Toggle `/pos` funcionando para `legacy|modern`.
+- [x] No-regresión de desacoplamiento validada por test automático.
+- [x] Documentación de rutas, riesgos y rollback actualizada.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
-    "new": "node scripts/new.mjs"
+    "new": "node scripts/new.mjs",
+    "test": "node scripts/run-modern-tests.mjs"
   },
   "dependencies": {
     "axios": "^1.6.5",

--- a/scripts/run-modern-tests.mjs
+++ b/scripts/run-modern-tests.mjs
@@ -1,0 +1,40 @@
+import { mkdirSync, rmSync } from "node:fs";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { build } from "esbuild";
+
+const projectRoot = process.cwd();
+const outDir = resolve(projectRoot, ".tmp-modern-tests");
+
+const suites = [
+  { name: "unit-products-service", entry: "tests/new/pos/products/products.service.unit.ts" },
+  { name: "integration-products-api-service-page", entry: "tests/new/pos/products/products.integration.ts" },
+  { name: "decoupling-no-legacy-imports", entry: "tests/new/architecture/decoupling.no-legacy-imports.ts" },
+];
+
+rmSync(outDir, { recursive: true, force: true });
+mkdirSync(outDir, { recursive: true });
+
+for (const suite of suites) {
+  const outfile = resolve(outDir, `${suite.name}.mjs`);
+
+  await build({
+    entryPoints: [resolve(projectRoot, suite.entry)],
+    outfile,
+    bundle: true,
+    format: "esm",
+    platform: "node",
+    target: "node20",
+    sourcemap: false,
+    logLevel: "silent",
+  });
+
+  const mod = await import(pathToFileURL(outfile).href);
+  if (typeof mod.run !== "function") {
+    throw new Error(`Suite ${suite.name} does not export run()`);
+  }
+  await mod.run();
+  console.log(`PASS ${suite.name}`);
+}
+
+console.log("All modern POS tests passed.");

--- a/src/Components/Rutas/newRoutesConfig.jsx
+++ b/src/Components/Rutas/newRoutesConfig.jsx
@@ -16,8 +16,20 @@ import { EditClient } from "../CatalogoWeb/PuntoVenta/Customers/EditClient";
 import { Employees } from "../CatalogoWeb/PuntoVenta/Employees/Employees";
 import { NewEmployee } from "../CatalogoWeb/PuntoVenta/Employees/NewEmployee";
 import { EditEmployee } from "../CatalogoWeb/PuntoVenta/Employees/EditEmployee";
+import { PosModeEntryPage } from "../../new/systems/pos/routing/PosModeEntryPage";
+import { ProductsV2PosPage } from "../../new/systems/pos/features/products/ui/ProductsV2PosPage";
+import { PosHealthV2Screen } from "../../new/systems/pos/features/health/ui/PosHealthV2Screen";
 
 export const NEW_PRIMARY_ROUTES = [
+  { path: "/pos", element: <PosModeEntryPage /> },
+  {
+    path: "/v2/pos",
+    children: [
+      { path: "", element: <ProductsV2PosPage /> },
+      { path: "products", element: <ProductsV2PosPage /> },
+      { path: "health", element: <PosHealthV2Screen /> },
+    ],
+  },
   { path: "/", element: <LandingRavekhPage /> },
   { path: "/RavekhPos", element: <RavekhPos /> },
   { path: "/login-punto-venta", element: <AuthPage /> },

--- a/src/new/README.md
+++ b/src/new/README.md
@@ -49,6 +49,7 @@ Each feature in every system now includes all architecture layers: `api`, `inter
 - `inventory-management`
   - Focused on inventory listing, low-stock detection, and stock updates.
 - `auth-onboarding`
+- `health-monitoring`
   - Focused on login and sign-up onboarding flows with validation and decoupled API mapping.
 - `table-zone-management`
   - Focused on table-zone listing, table-zone upsert operations, and business-level table-order activation.

--- a/src/new/index.ts
+++ b/src/new/index.ts
@@ -19,6 +19,7 @@ import { PosTableZoneApi } from "./systems/pos/features/settings/table-zones/api
 import { PosSalesTaxApi } from "./systems/pos/features/settings/tax/api/PosSalesTaxApi";
 import { PosPaymentMethodApi } from "./systems/pos/features/settings/payment-methods/api/PosPaymentMethodApi";
 import { PosBrandingApi } from "./systems/pos/features/settings/branding/api/PosBrandingApi";
+import { PosHealthApi } from "./systems/pos/features/health/api/PosHealthApi";
 import {
   AuthOnboardingPage,
   AuthOnboardingService,
@@ -56,6 +57,8 @@ import {
   PaymentMethodService,
   BrandingCustomizationPage,
   BrandingService,
+  HealthPage,
+  HealthService,
 } from "./systems/pos";
 import { CatalogPublishingPage, CatalogService } from "./systems/catalog";
 import { RewardsManagementPage, RewardService } from "./systems/loyalty";
@@ -209,6 +212,14 @@ export class ModernSystemsFactory {
 
   createPosBrandingPage(): BrandingCustomizationPage {
     return new BrandingCustomizationPage(this.createPosBrandingService());
+  }
+
+  createPosHealthService(): HealthService {
+    return new HealthService(new PosHealthApi(this.httpClient));
+  }
+
+  createPosHealthPage(): HealthPage {
+    return new HealthPage(this.createPosHealthService());
   }
 
   createCatalogService(): CatalogService {

--- a/src/new/systems/FEATURES.md
+++ b/src/new/systems/FEATURES.md
@@ -37,6 +37,7 @@ All POS modules are standardized under `src/new/systems/pos/features`.
 - `online-orders`
 - `cash-closing`
 - `auth`
+- `health`
 - `settings/business`
 - `settings/tax`
 - `settings/table-zones`

--- a/src/new/systems/pos/features/README.md
+++ b/src/new/systems/pos/features/README.md
@@ -28,6 +28,7 @@ All POS modules now live under:
 - `online-orders`
 - `cash-closing`
 - `auth`
+- `health`
 
 ### Settings subfeatures
 

--- a/src/new/systems/pos/features/health/api/PosHealthApi.ts
+++ b/src/new/systems/pos/features/health/api/PosHealthApi.ts
@@ -1,0 +1,20 @@
+import { HttpClient } from "../../../../core/api/HttpClient";
+import { IHealthRepository } from "../interface/IHealthRepository";
+import { HealthStatus } from "../model/HealthStatus";
+
+type HealthResponse = {
+  status?: string;
+};
+
+export class PosHealthApi implements IHealthRepository {
+  constructor(private readonly httpClient: HttpClient) {}
+
+  async check(): Promise<HealthStatus> {
+    const response = await this.httpClient.request<HealthResponse>({
+      method: "GET",
+      path: "health",
+    });
+
+    return new HealthStatus(response.status ?? "unknown", new Date().toISOString());
+  }
+}

--- a/src/new/systems/pos/features/health/interface/IHealthRepository.ts
+++ b/src/new/systems/pos/features/health/interface/IHealthRepository.ts
@@ -1,0 +1,5 @@
+import { HealthStatus } from "../model/HealthStatus";
+
+export interface IHealthRepository {
+  check(): Promise<HealthStatus>;
+}

--- a/src/new/systems/pos/features/health/model/HealthStatus.ts
+++ b/src/new/systems/pos/features/health/model/HealthStatus.ts
@@ -1,0 +1,10 @@
+export class HealthStatus {
+  constructor(
+    public readonly status: string,
+    public readonly checkedAt: string,
+  ) {}
+
+  isHealthy(): boolean {
+    return this.status.toLowerCase() === "ok";
+  }
+}

--- a/src/new/systems/pos/features/health/pages/HealthPage.ts
+++ b/src/new/systems/pos/features/health/pages/HealthPage.ts
@@ -1,0 +1,21 @@
+import { HealthService } from "../services/HealthService";
+
+export type HealthVm = {
+  status: string;
+  checkedAt: string;
+  healthy: boolean;
+};
+
+export class HealthPage {
+  constructor(private readonly service: HealthService) {}
+
+  async loadHealth(): Promise<HealthVm> {
+    const health = await this.service.checkStatus();
+
+    return {
+      status: health.status,
+      checkedAt: health.checkedAt,
+      healthy: health.isHealthy(),
+    };
+  }
+}

--- a/src/new/systems/pos/features/health/services/HealthService.ts
+++ b/src/new/systems/pos/features/health/services/HealthService.ts
@@ -1,0 +1,10 @@
+import { IHealthRepository } from "../interface/IHealthRepository";
+import { HealthStatus } from "../model/HealthStatus";
+
+export class HealthService {
+  constructor(private readonly repository: IHealthRepository) {}
+
+  async checkStatus(): Promise<HealthStatus> {
+    return this.repository.check();
+  }
+}

--- a/src/new/systems/pos/features/health/ui/PosHealthV2Screen.tsx
+++ b/src/new/systems/pos/features/health/ui/PosHealthV2Screen.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useMemo, useState } from "react";
+import { ModernSystemsFactory } from "../../../../../index";
+import { HealthVm } from "../pages/HealthPage";
+
+const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? "https://apipos.ravekh.com/api/";
+
+export const PosHealthV2Screen = () => {
+  const [health, setHealth] = useState<HealthVm | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const page = useMemo(() => {
+    const factory = new ModernSystemsFactory(API_BASE_URL);
+    return factory.createPosHealthPage();
+  }, []);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const run = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const currentHealth = await page.loadHealth();
+        if (mounted) {
+          setHealth(currentHealth);
+        }
+      } catch (cause) {
+        if (mounted) {
+          setError(cause instanceof Error ? cause.message : "Unable to validate API health.");
+        }
+      } finally {
+        if (mounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    run();
+
+    return () => {
+      mounted = false;
+    };
+  }, [page]);
+
+  return (
+    <section style={{ padding: "1.5rem" }}>
+      <h1>POS v2 • Health</h1>
+      {loading ? <p>Cargando health…</p> : null}
+      {error ? <p role="alert">{error}</p> : null}
+      {health ? (
+        <ul>
+          <li>status: {health.status}</li>
+          <li>healthy: {String(health.healthy)}</li>
+          <li>checkedAt: {health.checkedAt}</li>
+        </ul>
+      ) : null}
+    </section>
+  );
+};

--- a/src/new/systems/pos/features/products/ui/ProductsV2PosPage.tsx
+++ b/src/new/systems/pos/features/products/ui/ProductsV2PosPage.tsx
@@ -1,0 +1,165 @@
+import { FormEvent, useEffect, useMemo, useState } from "react";
+import { ModernSystemsFactory } from "../../../../../index";
+import { SaveManagedProductDto } from "../model/ManagedProduct";
+
+const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? "https://apipos.ravekh.com/api/";
+const DEFAULT_BUSINESS_ID = Number(import.meta.env.VITE_POS_BUSINESS_ID ?? 0);
+const TOKEN_KEY = "pos-v2-token";
+
+type ProductItemVm = {
+  id: number;
+  name: string;
+  available: boolean;
+};
+
+export const ProductsV2PosPage = () => {
+  const [businessId, setBusinessId] = useState(DEFAULT_BUSINESS_ID);
+  const [token, setToken] = useState(() => window.localStorage.getItem(TOKEN_KEY) ?? "");
+  const [products, setProducts] = useState<ProductItemVm[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [price, setPrice] = useState("0");
+  const [stock, setStock] = useState("0");
+
+  const page = useMemo(() => {
+    const factory = new ModernSystemsFactory(API_BASE_URL);
+    return factory.createPosProductsPage();
+  }, []);
+
+  const loadProducts = async () => {
+    if (!businessId || !token) {
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const list = await page.loadProducts(businessId, token);
+      setProducts(list);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "No se pudo cargar productos v2.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    window.localStorage.setItem(TOKEN_KEY, token);
+  }, [token]);
+
+  useEffect(() => {
+    loadProducts();
+  }, [businessId, token]);
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+
+    if (!businessId) {
+      setError("Business ID es obligatorio.");
+      return;
+    }
+
+    if (!token) {
+      setError("Token es obligatorio para operar POS v2.");
+      return;
+    }
+
+    const payload: SaveManagedProductDto = {
+      businessId,
+      name,
+      description,
+      forSale: true,
+      showInStore: true,
+      available: true,
+      price: Number(price),
+      stock: Number(stock),
+      costPerItem: null,
+      barcode: null,
+      categoryId: null,
+      images: [],
+      variants: [],
+    };
+
+    setSaving(true);
+    setError(null);
+
+    try {
+      await page.saveProduct(payload, token);
+      setName("");
+      setDescription("");
+      setPrice("0");
+      setStock("0");
+      await loadProducts();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "No se pudo guardar producto.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleArchive = async (productId: number) => {
+    if (!token) {
+      setError("Token es obligatorio para archivar.");
+      return;
+    }
+
+    try {
+      await page.archiveProduct(productId, token);
+      await loadProducts();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "No se pudo archivar producto.");
+    }
+  };
+
+  return (
+    <section style={{ padding: "1.5rem", maxWidth: "960px", margin: "0 auto" }}>
+      <header>
+        <h1>POS v2 · Products</h1>
+        <p>Implementación real API → Service → Page, aislada del legacy.</p>
+      </header>
+
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "1rem", marginBottom: "1rem" }}>
+        <label>
+          Business ID
+          <input type="number" value={businessId || ""} onChange={(event) => setBusinessId(Number(event.target.value))} />
+        </label>
+        <label>
+          Token
+          <input value={token} onChange={(event) => setToken(event.target.value)} placeholder="JWT token" />
+        </label>
+      </div>
+
+      <form onSubmit={handleSubmit} style={{ display: "grid", gap: "0.75rem", marginBottom: "1.25rem" }}>
+        <h2>Alta de producto</h2>
+        <input value={name} onChange={(event) => setName(event.target.value)} placeholder="Nombre" required />
+        <input value={description} onChange={(event) => setDescription(event.target.value)} placeholder="Descripción" required />
+        <input type="number" min="0" step="0.01" value={price} onChange={(event) => setPrice(event.target.value)} placeholder="Precio" required />
+        <input type="number" min="0" step="1" value={stock} onChange={(event) => setStock(event.target.value)} placeholder="Stock" required />
+        <button type="submit" disabled={saving}>{saving ? "Guardando..." : "Guardar"}</button>
+      </form>
+
+      {loading ? <p>Cargando productos...</p> : null}
+      {error ? <p role="alert">{error}</p> : null}
+
+      <h2>Listado</h2>
+      <ul>
+        {products.map((product) => (
+          <li key={product.id} style={{ display: "flex", justifyContent: "space-between", gap: "1rem", marginBottom: "0.5rem" }}>
+            <span>
+              #{product.id} · {product.name} · {product.available ? "Disponible" : "Archivado"}
+            </span>
+            {product.available ? (
+              <button type="button" onClick={() => handleArchive(product.id)}>
+                Archivar
+              </button>
+            ) : null}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+};

--- a/src/new/systems/pos/index.ts
+++ b/src/new/systems/pos/index.ts
@@ -35,3 +35,6 @@ export * from "./features/settings/payment-methods/pages/PaymentMethodManagement
 export * from "./features/settings/payment-methods/services/PaymentMethodService";
 export * from "./features/settings/branding/pages/BrandingCustomizationPage";
 export * from "./features/settings/branding/services/BrandingService";
+
+export * from "./features/health/pages/HealthPage";
+export * from "./features/health/services/HealthService";

--- a/src/new/systems/pos/routing/PosModeEntryPage.tsx
+++ b/src/new/systems/pos/routing/PosModeEntryPage.tsx
@@ -1,0 +1,29 @@
+import { useMemo } from "react";
+import { Navigate, useLocation } from "react-router-dom";
+import { getStoredPosRoutingMode, PosRoutingMode, savePosRoutingMode } from "./PosRoutingMode";
+
+const LEGACY_ENTRY = "/MainSales";
+const MODERN_ENTRY = "/v2/pos/products";
+
+const parseMode = (raw: string | null): PosRoutingMode | null => {
+  if (raw === "legacy" || raw === "modern") {
+    return raw;
+  }
+
+  return null;
+};
+
+export const PosModeEntryPage = () => {
+  const location = useLocation();
+
+  const redirectPath = useMemo(() => {
+    const queryMode = parseMode(new URLSearchParams(location.search).get("mode"));
+    const mode = queryMode ?? getStoredPosRoutingMode();
+
+    savePosRoutingMode(mode);
+
+    return mode === "legacy" ? LEGACY_ENTRY : MODERN_ENTRY;
+  }, [location.search]);
+
+  return <Navigate to={redirectPath} replace />;
+};

--- a/src/new/systems/pos/routing/PosRoutingMode.ts
+++ b/src/new/systems/pos/routing/PosRoutingMode.ts
@@ -1,0 +1,12 @@
+export type PosRoutingMode = "legacy" | "modern";
+
+export const POS_ROUTING_MODE_KEY = "pos-routing-mode";
+
+export const getStoredPosRoutingMode = (): PosRoutingMode => {
+  const current = window.localStorage.getItem(POS_ROUTING_MODE_KEY);
+  return current === "legacy" ? "legacy" : "modern";
+};
+
+export const savePosRoutingMode = (mode: PosRoutingMode): void => {
+  window.localStorage.setItem(POS_ROUTING_MODE_KEY, mode);
+};

--- a/src/new/systems/pos/routing/PosV2Routes.tsx
+++ b/src/new/systems/pos/routing/PosV2Routes.tsx
@@ -1,0 +1,11 @@
+import { Navigate, Route } from "react-router-dom";
+import { ProductsV2PosPage } from "../features/products/ui/ProductsV2PosPage";
+import { PosHealthV2Screen } from "../features/health/ui/PosHealthV2Screen";
+
+export const POS_V2_ROUTES = (
+  <Route path="/v2/pos">
+    <Route index element={<Navigate to="products" replace />} />
+    <Route path="products" element={<ProductsV2PosPage />} />
+    <Route path="health" element={<PosHealthV2Screen />} />
+  </Route>
+);

--- a/tests/new/architecture/decoupling.no-legacy-imports.ts
+++ b/tests/new/architecture/decoupling.no-legacy-imports.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { globSync } from "glob";
+
+export async function run(): Promise<void> {
+  const root = resolve(process.cwd());
+  const files = globSync("src/new/systems/pos/**/*.{ts,tsx,js,jsx}", { cwd: root, nodir: true });
+
+  const violations = files.filter((file) => {
+    const content = readFileSync(resolve(root, file), "utf8");
+    return /from\s+["'][^"']*Components\//.test(content) || /import\s+["'][^"']*Components\//.test(content);
+  });
+
+  assert.deepEqual(violations, [], `Found forbidden imports in src/new/systems/pos: ${violations.join(", ")}`);
+}

--- a/tests/new/pos/products/products.integration.ts
+++ b/tests/new/pos/products/products.integration.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { PosProductsApi } from "../../../../src/new/systems/pos/features/products/api/PosProductsApi";
+import { ProductsService } from "../../../../src/new/systems/pos/features/products/services/ProductsService";
+import { ProductsManagementPage } from "../../../../src/new/systems/pos/features/products/pages/ProductsManagementPage";
+
+export async function run(): Promise<void> {
+  const calls: string[] = [];
+
+  const httpClient = {
+    request: async ({ method, path }: { method: string; path: string }) => {
+      calls.push(`${method} ${path}`);
+
+      if (method === "GET" && path === "products/business/7") {
+        return [{ Id: 1, Business_Id: 7, Name: "Café", Available: true }];
+      }
+
+      if (method === "POST" && path === "products") {
+        return undefined;
+      }
+
+      if (method === "PUT" && path === "products/available/8") {
+        return undefined;
+      }
+
+      throw new Error(`Unexpected request ${method} ${path}`);
+    },
+  };
+
+  const api = new PosProductsApi(httpClient);
+  const service = new ProductsService(api);
+  const page = new ProductsManagementPage(service);
+
+  const vm = await page.loadProducts(7, "token");
+  assert.deepEqual(vm, [{ id: 1, name: "Café", available: true }]);
+
+  const saved = await page.saveProduct(
+    {
+      businessId: 7,
+      name: "Té",
+      description: "Bebida",
+      forSale: true,
+      showInStore: true,
+      available: true,
+      images: [],
+    },
+    "token",
+  );
+
+  await page.archiveProduct(8, "token");
+
+  assert.deepEqual(saved, { id: 0, name: "Té", available: true });
+  assert.deepEqual(calls, ["GET products/business/7", "POST products", "PUT products/available/8"]);
+}

--- a/tests/new/pos/products/products.service.unit.ts
+++ b/tests/new/pos/products/products.service.unit.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { ProductsService } from "../../../../src/new/systems/pos/features/products/services/ProductsService";
+import { ManagedProduct } from "../../../../src/new/systems/pos/features/products/model/ManagedProduct";
+
+const buildProduct = (id: number, available = true) =>
+  new ManagedProduct(id, 10, `Product ${id}`, "desc", true, true, available, null, 30, 10, 2, null, [], null, []);
+
+export async function run(): Promise<void> {
+  const createRepo = {
+    listByBusiness: async () => [],
+    getById: async () => null,
+    create: async () => buildProduct(101),
+    update: async () => buildProduct(999),
+    archive: async () => undefined,
+  };
+
+  const createService = new ProductsService(createRepo);
+  const created = await createService.saveProduct(
+    {
+      businessId: 10,
+      name: "New",
+      description: "Desc",
+      forSale: true,
+      showInStore: true,
+      available: true,
+      images: [],
+    },
+    "token",
+  );
+
+  assert.equal(created.id, 101, "create flow should return created product");
+
+  const updateRepo = {
+    ...createRepo,
+    create: async () => {
+      throw new Error("create should not run in update flow");
+    },
+    update: async () => buildProduct(77),
+  };
+
+  const updateService = new ProductsService(updateRepo);
+  const updated = await updateService.saveProduct(
+    {
+      id: 77,
+      businessId: 10,
+      name: "Updated",
+      description: "Desc",
+      forSale: true,
+      showInStore: true,
+      available: true,
+      images: [],
+    },
+    "token",
+  );
+
+  assert.equal(updated.id, 77, "update flow should return updated product");
+
+  let archivedId = 0;
+  const archiveRepo = {
+    ...createRepo,
+    archive: async (id: number) => {
+      archivedId = id;
+    },
+  };
+
+  const archiveService = new ProductsService(archiveRepo);
+  await archiveService.archiveProduct(55, "token");
+  assert.equal(archivedId, 55, "archive should call repository with product id");
+}


### PR DESCRIPTION
### Motivation

- Entregar una implementación real y desacoplada de la feature prioritara POS v2 `products` (no placeholders) usando la nueva arquitectura `API -> Service -> Page -> UI` y sin depender del código legacy. 
- Mantener coexistencia segura con la aplicación legacy (no romper rutas existentes) y ofrecer un entrypoint unificado `/pos` con toggle `legacy|modern` para migraciones incrementales. 
- Añadir cobertura automática que valide comportamiento de dominio, integración end-to-end API→Service→Page y la ausencia de acoplamientos accidentales al legacy. 

### Description

- Añadida la UI y flujo real de `products` bajo la nueva arquitectura en `src/new/systems/pos/features/products/ui/ProductsV2PosPage.tsx` consumiendo `ProductsManagementPage`/`ProductsService`/`PosProductsApi` (lista, crear, archivar).  
- Implementada feature `health` completa (`model`, `interface`, `api`, `services`, `pages`, `ui`) para smoke-check del backend y wiring en `ModernSystemsFactory` (`createPosHealthPage`). 
- Nuevo routing y toggle POS: `src/new/systems/pos/routing/PosModeEntryPage.tsx`, `PosRoutingMode.ts` y `PosV2Routes.tsx`, además de la incorporación en el catálogo de rutas (`src/Components/Rutas/newRoutesConfig.jsx`) exponiendo `/pos` y `/v2/pos/*` sin modificar rutas legacy. 
- Wiring y export updates en `src/new/index.ts` y `src/new/systems/pos/index.ts` para publicar `HealthPage`/`HealthService`, más documentación `docs/pos-v2-products-iteration.md`. 
- Tests y util runner: añadidos tests de unidad e integración en `tests/new/pos/products/` y test de desacoplamiento en `tests/new/architecture/`; creado `scripts/run-modern-tests.mjs` y agregado `test` script en `package.json` para ejecutar las suites con `esbuild` bundling (evita añadir dependencias bloqueadas). 

### Testing

- Ejecuté `npm test` (ejecuta `scripts/run-modern-tests.mjs`) y las suites automáticas pasaron: `unit-products-service`, `integration-products-api-service-page`, `decoupling-no-legacy-imports` — salida: all PASS. 
- Ejecuté `npm run build` y el build de Vite concluyó correctamente (producción generada). 
- Ejecuté `npm run lint` como verificación y falló por errores preexistentes en el código legacy; esto es un problema independiente y no causado por los cambios `src/new` de esta PR.

Comandos claves ejecutados y su resultado: `npm test` → passed; `npm run build` → passed; `npm run lint` → failed (legacy issues).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc1426f3408324827ea7bd3be92130)