### PR TITLE
Decouple loyalty coupons v2 from legacy constants and standardize icon usage

### DIFF
--- a/src/new/systems/loyalty/features/coupons/config/couponsEnv.ts
+++ b/src/new/systems/loyalty/features/coupons/config/couponsEnv.ts
@@ -1,0 +1,17 @@
+const DEFAULT_API_BASE_URL = "https://apipos.ravekh.com/api/";
+const DEFAULT_WEB_COUPONS_DOMAIN = "https://ravekh.com";
+
+const ensureTrailingSlash = (value: string): string => {
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+  return trimmed.endsWith("/") ? trimmed : `${trimmed}/`;
+};
+
+const resolveApiBaseUrl = (): string =>
+  ensureTrailingSlash(import.meta.env.VITE_POS_API_URL ?? import.meta.env.VITE_COUPONS_API_URL ?? DEFAULT_API_BASE_URL);
+
+const resolveWebCouponsDomain = (): string =>
+  (import.meta.env.VITE_WEB_COUPONS_DOMAIN ?? DEFAULT_WEB_COUPONS_DOMAIN).trim();
+
+export const COUPONS_API_URL = resolveApiBaseUrl();
+export const WEB_COUPONS_DOMAIN = resolveWebCouponsDomain();

--- a/src/new/systems/loyalty/features/coupons/pages/CouponQrPage.tsx
+++ b/src/new/systems/loyalty/features/coupons/pages/CouponQrPage.tsx
@@ -7,7 +7,8 @@ import { CuponesNav } from "../interface/CouponsNav";
 import { useCouponsTheme } from "../interface/useCouponsTheme";
 import { getCuponesUserId, getCuponesUserName, hasCuponesSession } from "../services/session";
 import type { Coupon } from "../models/coupon";
-import {WEB_COUPONS_DOMAIN} from "../../../../../../Components/CatalogoWeb/Cupones/shared/constants";
+import { WEB_COUPONS_DOMAIN } from "../config/couponsEnv";
+import { FiArrowLeft } from "react-icons/fi";
 
 const CouponQrPage: React.FC = () => {
   const navigate = useNavigate();
@@ -102,7 +103,7 @@ const CouponQrPage: React.FC = () => {
             className="h-12 w-12 rounded-2xl border flex items-center justify-center shadow-[0_12px_24px_rgba(0,0,0,0.12)]"
             style={{ backgroundColor: theme.surface, borderColor: theme.border }}
           >
-            <span className="text-lg">←</span>
+            <FiArrowLeft size={20} aria-hidden="true" />
           </button>
           <div className="flex items-center gap-3">
             <div

--- a/src/new/systems/loyalty/features/coupons/services/couponsApi.ts
+++ b/src/new/systems/loyalty/features/coupons/services/couponsApi.ts
@@ -1,4 +1,4 @@
-import { URL } from "../../../../../../Components/CatalogoWeb/Const/Const";
+import { COUPONS_API_URL } from "../config/couponsEnv";
 import type { ClaimCouponPayload, Coupon, CouponHasUser, CreateCouponPayload } from "../models/coupon";
 import type { LoginPayload } from "../models/auth";
 
@@ -39,7 +39,7 @@ const buildHttpError = async (response: Response, fallback: string): Promise<Err
 };
 
 const createCoupon = async (payload: CreateCouponPayload): Promise<Response> => {
-  const response = await fetch(`${URL}coupons`, {
+  const response = await fetch(`${COUPONS_API_URL}coupons`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -59,7 +59,7 @@ const getCouponsByBusiness = async (businessId: number): Promise<Coupon[]> => {
     return [];
   }
 
-  const response = await fetch(`${URL}coupons/business/${businessId}`);
+  const response = await fetch(`${COUPONS_API_URL}coupons/business/${businessId}`);
 
   if (!response.ok) {
     throw await buildHttpError(response, "No se pudieron cargar los cupones.");
@@ -74,7 +74,7 @@ const getCouponById = async (couponId: number): Promise<Coupon | null> => {
     return null;
   }
 
-  const response = await fetch(`${URL}coupons/${couponId}`);
+  const response = await fetch(`${COUPONS_API_URL}coupons/${couponId}`);
 
   if (!response.ok) {
     throw await buildHttpError(response, "No se pudo cargar el cupón.");
@@ -89,7 +89,7 @@ const getCouponDisponibility = async (userId: number): Promise<Coupon[] | null> 
   }
 
   try {
-    const response = await fetch(`${URL}coupons/user/${userId}`);
+    const response = await fetch(`${COUPONS_API_URL}coupons/user/${userId}`);
     if (!response.ok) {
       throw await buildHttpError(response, "No se pudieron cargar las relaciones de cupones del usuario.");
     }
@@ -107,7 +107,7 @@ const getCouponsByUser = async (userId: number): Promise<CouponHasUser[] | null>
   }
 
   try {
-    const response = await fetch(`${URL}couponhasusers/user/${userId}`);
+    const response = await fetch(`${COUPONS_API_URL}couponhasusers/user/${userId}`);
     if (!response.ok) {
       throw await buildHttpError(response, "No se pudieron cargar las relaciones de cupones del usuario.");
     }
@@ -132,7 +132,7 @@ const getClaimedCouponsByUser = async (userId: number): Promise<Coupon[]> => {
 };
 
 const claimCoupon = async (payload: ClaimCouponPayload): Promise<unknown> => {
-  const response = await fetch(`${URL}coupons/take`, {
+  const response = await fetch(`${COUPONS_API_URL}coupons/take`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -152,7 +152,7 @@ const redeemCouponByUser = async (couponId: number, userId: number): Promise<unk
     throw new Error("Datos inválidos para reclamar el cupón.");
   }
 
-  const response = await fetch(`${URL}couponhasusers/coupon/${couponId}/user/${userId}`, {
+  const response = await fetch(`${COUPONS_API_URL}couponhasusers/coupon/${couponId}/user/${userId}`, {
     method: "PUT",
     headers: {
       "Content-Type": "application/json",
@@ -178,7 +178,7 @@ const getCouponsDisponibilityByUser = async (userId: number): Promise<Coupon[]> 
 };
 
 const updateCoupon = async (couponId: number, payload: CreateCouponPayload): Promise<Response> => {
-  const response = await fetch(`${URL}coupons/${couponId}`, {
+  const response = await fetch(`${COUPONS_API_URL}coupons/${couponId}`, {
     method: "PUT",
     headers: {
       "Content-Type": "application/json",
@@ -194,7 +194,7 @@ const updateCoupon = async (couponId: number, payload: CreateCouponPayload): Pro
 };
 
 const deleteCoupon = async (couponId: number): Promise<Response> => {
-  const response = await fetch(`${URL}coupons/${couponId}`, {
+  const response = await fetch(`${COUPONS_API_URL}coupons/${couponId}`, {
     method: "DELETE",
   });
 
@@ -206,7 +206,7 @@ const deleteCoupon = async (couponId: number): Promise<Response> => {
 };
 
 const deleteCouponsAccount = async (userId: number, token: string): Promise<{ message?: string } | null> => {
-  const response = await fetch(`${URL}employee/${userId}`, {
+  const response = await fetch(`${COUPONS_API_URL}employee/${userId}`, {
     method: "DELETE",
     headers: {
       "Content-Type": "application/json",
@@ -224,7 +224,7 @@ const deleteCouponsAccount = async (userId: number, token: string): Promise<{ me
 };
 
 const loginCupones = async (payload: LoginPayload): Promise<LoginResponse> => {
-  const response = await fetch(`${URL}Login`, {
+  const response = await fetch(`${COUPONS_API_URL}Login`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -240,7 +240,7 @@ const loginCupones = async (payload: LoginPayload): Promise<LoginResponse> => {
 };
 
 const registerCupones = async (payload: RegisterPayload): Promise<RegisterResponse> => {
-  const response = await fetch(`${URL}employee`, {
+  const response = await fetch(`${COUPONS_API_URL}employee`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -256,7 +256,7 @@ const registerCupones = async (payload: RegisterPayload): Promise<RegisterRespon
 };
 
 const resetPassword = async (body: { Email: string; Password: string }) => {
-  const url = `${URL}resetpassword`;
+  const url = `${COUPONS_API_URL}resetpassword`;
 
   const response = await fetch(url, {
     method: "PUT",

--- a/src/new/systems/loyalty/features/coupons/services/visitsApi.ts
+++ b/src/new/systems/loyalty/features/coupons/services/visitsApi.ts
@@ -1,4 +1,4 @@
-import { URL } from "../../../../../../Components/CatalogoWeb/Const/Const";
+import { COUPONS_API_URL } from "../config/couponsEnv";
 import type { Visits } from "../models/coupon";
 
 type RedeemVisitResponse = { visitCreated: boolean; couponGenerated: boolean };
@@ -9,7 +9,7 @@ type RedeemVisitPayload = Partial<RedeemVisitResponse> & {
 };
 
 const getVisitsByUserId = async (userId: number): Promise<Visits[]> => {
-  const endpoint = `${URL}visits/user/${userId}`;
+  const endpoint = `${COUPONS_API_URL}visits/user/${userId}`;
   const response = await fetch(endpoint);
   if (!response.ok) {
     throw new Error("No se pudieron cargar las visitas del usuario.");
@@ -18,7 +18,7 @@ const getVisitsByUserId = async (userId: number): Promise<Visits[]> => {
 };
 
 const getVisitHistoryByUserId = async (userId: number): Promise<Visits[]> => {
-  const endpoint = `${URL}visits/user/history/${userId}`;
+  const endpoint = `${COUPONS_API_URL}visits/user/history/${userId}`;
   const response = await fetch(endpoint);
   if (!response.ok) {
     throw new Error("No se pudo cargar el historial de visitas.");
@@ -50,7 +50,7 @@ const redeemVisitQr = async (
   userId: number,
   options?: { signal?: AbortSignal; regenerateDynamicQr?: boolean },
 ) => {
-  const response = await fetch(`${URL}visits/qr/redeem`, {
+  const response = await fetch(`${COUPONS_API_URL}visits/qr/redeem`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",


### PR DESCRIPTION
### Motivation
- Remove remaining coupling between the new loyalty coupons module and legacy `Components` constants so the new code can be maintained and tested independently. 
- Centralize web domain and API base URL for coupons to support environment overrides and avoid hidden cross-module dependencies. 
- Use `react-icons` for UI consistency and maintainability of iconography across the modern code paths. 

### Description
- Added `src/new/systems/loyalty/features/coupons/config/couponsEnv.ts` to provide `COUPONS_API_URL` and `WEB_COUPONS_DOMAIN` with safe defaults and trailing-slash normalization. 
- Updated `src/new/systems/loyalty/features/coupons/services/couponsApi.ts` to use `COUPONS_API_URL` instead of importing legacy `Components` constants. 
- Updated `src/new/systems/loyalty/features/coupons/services/visitsApi.ts` to use `COUPONS_API_URL` instead of legacy constants. 
- Updated `src/new/systems/loyalty/features/coupons/pages/CouponQrPage.tsx` to consume `WEB_COUPONS_DOMAIN` from the new config and replaced the textual back-arrow with `FiArrowLeft` from `react-icons` for consistent icon usage. 

### Testing
- Ran `npm run build` and the production build completed successfully. 
- Ran repository tests with `npm test` and observed preexisting esbuild failures related to `.svg/.png` loader handling in unrelated suites, so the failing test run is unrelated to these changes. 
- Verified with `rg` searches that the `src/new` modern code no longer imports the legacy `Components/...` constants referenced before.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdad6c00a48324abec4ee069e9dff1)