### PR TITLE
feat: modernizar sección de proyectos y agregar páginas de políticas de privacidad

### DIFF
--- a/src/new/routing/NewAppRoutes.tsx
+++ b/src/new/routing/NewAppRoutes.tsx
@@ -8,6 +8,8 @@ import { PosModeEntryPage } from "../systems/pos/routing/PosModeEntryPage";
 import { POS_V2_ROUTES } from "../systems/pos/routing/PosV2Routes";
 import { LoyaltyCustomerRoutes } from "../systems/loyalty/features/customer-experience/ui/LoyaltyCustomerRoutes";
 import { LoyaltyCustomerLegacyCloneRoutes } from "../systems/loyalty/features/customer-experience/ui/LoyaltyCustomerLegacyCloneRoutes";
+import { PrivacyPoliciesIndexPage } from "../systems/legal/pages/PrivacyPoliciesIndexPage";
+import { PrivacyPolicyPage } from "../systems/legal/pages/PrivacyPolicyPage";
 
 const LegacyCatalogRedirect = () => {
   const { idBusiness } = useParams<{ idBusiness: string }>();
@@ -43,6 +45,8 @@ export const NewAppRoutes = () => {
       <Route path="/v2/catalogo/pedido-info" element={<CatalogOrderInfoPage />} />
       <Route path="/v2/loyalty/customer/*" element={<LoyaltyCustomerRoutes />} />
       <Route path="/v2/loyalty/clone/*" element={<LoyaltyCustomerLegacyCloneRoutes />} />
+      <Route path="/politicas" element={<PrivacyPoliciesIndexPage />} />
+      <Route path="/politicas/:policySlug" element={<PrivacyPolicyPage />} />
 
       {/* Compatibilidad de URLs antiguas sin dependencias a módulos legacy */}
       <Route path="/catalogo/:idBusiness" element={<LegacyCatalogRedirect />} />

--- a/src/new/systems/landing-ravekh/Footer/pages/Footer.tsx
+++ b/src/new/systems/landing-ravekh/Footer/pages/Footer.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Link } from "react-router-dom";
 import fb from "../../assets/logo-facebook.svg";
 import ig from "../../assets/logo-instagram.svg";
 export const Footer = () => {
@@ -20,6 +21,24 @@ export const Footer = () => {
           <a target="_blank" href="https://www.instagram.com/rave_kh/">
             <img src={ig} alt="ig" />
           </a>
+        </div>
+
+        <div className="mt-8 grid gap-2 text-center">
+          <p className="text-white font-semibold">Políticas de privacidad</p>
+          <div className="flex flex-wrap justify-center gap-3 text-sm">
+            <Link to="/politicas/ravekh-pos" className="text-white underline">
+              Ravekh POS
+            </Link>
+            <Link to="/politicas/ravekh" className="text-white underline">
+              Ravekh
+            </Link>
+            <Link to="/politicas/lealtad" className="text-white underline">
+              Lealtad
+            </Link>
+            <Link to="/politicas/catalogo" className="text-white underline">
+              Catálogo
+            </Link>
+          </div>
         </div>
       </div>
     </div>

--- a/src/new/systems/landing-ravekh/Projects/pages/ProjectsShowcase.tsx
+++ b/src/new/systems/landing-ravekh/Projects/pages/ProjectsShowcase.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+import "../styles/ProjectsShowcase.css";
+
+interface ProjectItem {
+  title: string;
+  description: string;
+  status: string;
+  stack: string[];
+  link?: string;
+}
+
+const projects: ProjectItem[] = [
+  {
+    title: "Ravekh POS",
+    description:
+      "Punto de venta moderno para ventas, inventario, caja, reportes, finanzas y operación diaria.",
+    status: "Terminado",
+    stack: ["React", "TypeScript", "Vite"],
+    link: "/v2/login-punto-venta",
+  },
+  {
+    title: "Ravekh Lealtad",
+    description:
+      "Experiencia de fidelización con cupones, recompensas, historial de visitas y canje para clientes.",
+    status: "Terminado",
+    stack: ["React", "Customer Experience", "QR"],
+    link: "/v2/loyalty/clone/cupones",
+  },
+  {
+    title: "Ravekh Catálogo",
+    description:
+      "Catálogo online con productos, carrito, detalle y flujo de pedido para negocios locales.",
+    status: "Terminado",
+    stack: ["Storefront", "Carrito", "Pedidos"],
+    link: "/v2/catalogo/1",
+  },
+  {
+    title: "Landing Ravekh",
+    description:
+      "Landing comercial de alta conversión, optimizada para presentar soluciones digitales y captar clientes.",
+    status: "Terminado",
+    stack: ["Branding", "SEO Base", "UI Moderna"],
+    link: "/",
+  },
+];
+
+export const ProjectsShowcase = () => {
+  return (
+    <div className="projects-showcase" id="proyectos">
+      <div className="projects-showcase__header">
+        <span className="projects-showcase__eyebrow">Proyectos</span>
+        <h2>Proyectos terminados</h2>
+        <p>
+          Migramos lo legacy a una vitrina moderna para mostrar claramente los productos que ya están en producción.
+        </p>
+      </div>
+
+      <div className="projects-showcase__grid">
+        {projects.map((project) => (
+          <article className="project-card" key={project.title}>
+            <div className="project-card__top">
+              <h3>{project.title}</h3>
+              <span>{project.status}</span>
+            </div>
+
+            <p>{project.description}</p>
+
+            <ul>
+              {project.stack.map((item) => (
+                <li key={`${project.title}-${item}`}>{item}</li>
+              ))}
+            </ul>
+
+            {project.link ? (
+              <a href={project.link} className="project-card__link">
+                Ver proyecto
+              </a>
+            ) : null}
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/new/systems/landing-ravekh/Projects/styles/ProjectsShowcase.css
+++ b/src/new/systems/landing-ravekh/Projects/styles/ProjectsShowcase.css
@@ -1,0 +1,103 @@
+.projects-showcase {
+  min-height: 100vh;
+  background: radial-gradient(circle at top, #3f0277 0%, #130028 60%, #080012 100%);
+  color: #ffffff;
+  padding: 5rem 1.25rem 3rem;
+}
+
+.projects-showcase__header {
+  max-width: 960px;
+  margin: 0 auto 2rem;
+  text-align: center;
+}
+
+.projects-showcase__eyebrow {
+  display: inline-flex;
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  border-radius: 999px;
+  padding: 0.25rem 0.9rem;
+  font-size: 0.8rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.projects-showcase__header h2 {
+  margin-top: 1rem;
+  font-size: clamp(2rem, 4vw, 3rem);
+  font-weight: 800;
+}
+
+.projects-showcase__header p {
+  max-width: 740px;
+  margin: 0.9rem auto 0;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.projects-showcase__grid {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.project-card {
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 16px;
+  padding: 1rem;
+  background: rgba(255, 255, 255, 0.06);
+  backdrop-filter: blur(4px);
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.project-card__top {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.project-card__top h3 {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 700;
+}
+
+.project-card__top span {
+  font-size: 0.74rem;
+  border-radius: 999px;
+  padding: 0.3rem 0.6rem;
+  background: #ffffff;
+  color: #3f0277;
+  height: fit-content;
+}
+
+.project-card p {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.92);
+  line-height: 1.4;
+}
+
+.project-card ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.project-card li {
+  font-size: 0.72rem;
+  border: 1px solid rgba(255, 255, 255, 0.34);
+  border-radius: 999px;
+  padding: 0.2rem 0.6rem;
+}
+
+.project-card__link {
+  margin-top: auto;
+  color: #ffffff;
+  text-decoration: none;
+  font-weight: 700;
+}

--- a/src/new/systems/landing-ravekh/pages/LandingPage.css
+++ b/src/new/systems/landing-ravekh/pages/LandingPage.css
@@ -64,6 +64,16 @@
   font-weight: 700;
 }
 
+.floating-systems-menu__button {
+  background: transparent;
+  border: none;
+  color: #fff;
+  text-decoration: none;
+  font-size: clamp(1.7rem, 4.8vw, 2.4rem);
+  font-weight: 700;
+  cursor: pointer;
+}
+
 .floating-systems-menu__list a:hover {
   opacity: 0.9;
 }

--- a/src/new/systems/landing-ravekh/pages/LandingRavekhPage.tsx
+++ b/src/new/systems/landing-ravekh/pages/LandingRavekhPage.tsx
@@ -8,6 +8,7 @@ import { ProcessTwo } from "../Process-two/pages/ProcessTwo";
 import { ProcessThree } from "../Process-Three/pages/ProcessThree";
 import { ProcessFour } from "../Process-Four/pages/ProcessFour";
 import { ProcessFive } from "../Process-Five/pages/ProcessFive";
+import { ProjectsShowcase } from "../Projects/pages/ProjectsShowcase";
 import { Characteristics } from "../Characteristics/pages/Characteristics";
 import { Contact } from "../Contact/pages/Contact";
 import { Footer } from "../Footer/pages/Footer";
@@ -66,6 +67,17 @@ export const LandingPageRavekhPage = (): JSX.Element => {
 
     setIsSystemsMenuOpen(false);
     setIsSystemsMenuClosing(true);
+  };
+
+  const scrollToSection = (sectionId: string) => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const target = container.querySelector<HTMLElement>(`#${sectionId}`);
+    if (!target) return;
+
+    target.scrollIntoView({ behavior: "smooth", block: "start" });
+    closeSystemsMenu();
   };
 
   useEffect(() => {
@@ -141,6 +153,16 @@ export const LandingPageRavekhPage = (): JSX.Element => {
                   Catálogo público
                 </NavLink>
               </li>
+              <li>
+                <button type="button" onClick={() => scrollToSection("proyectos")} className="floating-systems-menu__button">
+                  Proyectos
+                </button>
+              </li>
+              <li>
+                <NavLink to="/politicas" onClick={closeSystemsMenu}>
+                  Políticas
+                </NavLink>
+              </li>
             </ul>
           </nav>
         )}
@@ -192,6 +214,13 @@ export const LandingPageRavekhPage = (): JSX.Element => {
           data-endcolor="0,0,0"
         >
           <Characteristics />
+        </section>
+
+        <section
+          className="snap-start w-full"
+          data-endcolor="20,0,40"
+        >
+          <ProjectsShowcase />
         </section>
 
         <section

--- a/src/new/systems/legal/pages/PrivacyPoliciesIndexPage.tsx
+++ b/src/new/systems/legal/pages/PrivacyPoliciesIndexPage.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { PRIVACY_POLICIES } from "./privacyPolicies";
+
+export const PrivacyPoliciesIndexPage = () => {
+  return (
+    <main className="min-h-screen bg-fondo-oscuro text-white px-4 py-10 md:px-10">
+      <div className="max-w-5xl mx-auto">
+        <Link to="/" className="inline-flex mb-6 text-sm underline">
+          ← Volver al inicio
+        </Link>
+
+        <h1 className="text-3xl md:text-4xl font-bold">Políticas de privacidad</h1>
+        <p className="text-white/80 mt-2">
+          Consulta la política correspondiente a cada producto de Ravekh.
+        </p>
+
+        <div className="grid gap-4 md:grid-cols-2 mt-8">
+          {PRIVACY_POLICIES.map((policy) => (
+            <article key={policy.slug} className="rounded-xl border border-white/15 bg-white/5 p-4">
+              <h2 className="font-semibold text-xl">{policy.title.replace("Política de Privacidad — ", "")}</h2>
+              <p className="text-white/80 mt-2">{policy.subtitle}</p>
+              <Link to={`/politicas/${policy.slug}`} className="inline-block mt-4 underline font-medium">
+                Ver política
+              </Link>
+            </article>
+          ))}
+        </div>
+      </div>
+    </main>
+  );
+};

--- a/src/new/systems/legal/pages/PrivacyPolicyPage.tsx
+++ b/src/new/systems/legal/pages/PrivacyPolicyPage.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { Link, Navigate, useParams } from "react-router-dom";
+import { PRIVACY_POLICIES } from "./privacyPolicies";
+
+import "../../landing-ravekh/pages/LandingPage.css";
+
+export const PrivacyPolicyPage = () => {
+  const { policySlug } = useParams<{ policySlug: string }>();
+  const policy = PRIVACY_POLICIES.find((item) => item.slug === policySlug);
+
+  if (!policy) {
+    return <Navigate to="/politicas" replace />;
+  }
+
+  return (
+    <main className="min-h-screen bg-fondo-oscuro text-white px-4 py-10 md:px-10">
+      <div className="max-w-5xl mx-auto">
+        <Link to="/" className="inline-flex mb-6 text-sm underline">
+          ← Volver al inicio
+        </Link>
+
+        <div className="rounded-2xl border border-white/20 bg-white/5 p-5 md:p-8">
+          <h1 className="text-3xl md:text-4xl font-bold">{policy.title}</h1>
+          <p className="text-white/80 mt-2">{policy.subtitle}</p>
+
+          <div className="grid gap-4 mt-8">
+            {policy.sections.map((section) => (
+              <section
+                key={`${policy.slug}-${section.title}`}
+                className="rounded-xl border border-white/15 bg-black/20 p-4"
+              >
+                <h2 className="font-semibold text-xl">{section.title}</h2>
+                <p className="text-white/85 mt-2 leading-relaxed">{section.content}</p>
+              </section>
+            ))}
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+};

--- a/src/new/systems/legal/pages/privacyPolicies.ts
+++ b/src/new/systems/legal/pages/privacyPolicies.ts
@@ -1,0 +1,122 @@
+export interface PolicySection {
+  title: string;
+  content: string;
+}
+
+export interface PolicyDocument {
+  slug: string;
+  title: string;
+  subtitle: string;
+  sections: PolicySection[];
+}
+
+export const PRIVACY_POLICIES: PolicyDocument[] = [
+  {
+    slug: "ravekh-pos",
+    title: "Política de Privacidad — Ravekh POS",
+    subtitle: "Gestión de ventas, operación, finanzas y configuración del negocio.",
+    sections: [
+      {
+        title: "1. Datos que tratamos",
+        content:
+          "Tratamos datos operativos del negocio como ventas, productos, inventario, egresos e información básica de usuarios de la cuenta para habilitar el servicio.",
+      },
+      {
+        title: "2. Finalidad",
+        content:
+          "Usamos la información para administrar el punto de venta, generar reportes, mejorar estabilidad, prevenir fraude y ofrecer soporte técnico.",
+      },
+      {
+        title: "3. Conservación",
+        content:
+          "Conservamos los datos durante el tiempo necesario para prestar el servicio y cumplir obligaciones legales o fiscales aplicables.",
+      },
+      {
+        title: "4. Derechos",
+        content:
+          "Puedes solicitar acceso, corrección o eliminación de datos, así como limitar ciertos tratamientos mediante los canales oficiales de soporte.",
+      },
+    ],
+  },
+  {
+    slug: "ravekh",
+    title: "Política de Privacidad — Ravekh",
+    subtitle: "Sitio web y canales de contacto de la marca.",
+    sections: [
+      {
+        title: "1. Datos que tratamos",
+        content:
+          "Podemos tratar nombre, correo, teléfono y mensajes cuando nos contactas por formularios, redes sociales o mensajería.",
+      },
+      {
+        title: "2. Finalidad",
+        content:
+          "Usamos la información para responder solicitudes comerciales, compartir propuestas y mejorar la experiencia digital del sitio.",
+      },
+      {
+        title: "3. Compartición",
+        content:
+          "No vendemos datos personales. Solo compartimos con proveedores que nos ayudan a operar el servicio bajo medidas de confidencialidad.",
+      },
+      {
+        title: "4. Derechos",
+        content:
+          "Puedes solicitar la actualización o baja de tus datos enviando tu solicitud por los medios de contacto oficiales.",
+      },
+    ],
+  },
+  {
+    slug: "lealtad",
+    title: "Política de Privacidad — Lealtad",
+    subtitle: "Programa de recompensas, cupones y visitas de clientes.",
+    sections: [
+      {
+        title: "1. Datos que tratamos",
+        content:
+          "Podemos tratar nombre, teléfono, historial de visitas, cupones, canjes y actividad del usuario para operar beneficios.",
+      },
+      {
+        title: "2. Finalidad",
+        content:
+          "La información permite acumular visitas, habilitar cupones, evitar usos indebidos y personalizar la experiencia de recompensas.",
+      },
+      {
+        title: "3. Seguridad",
+        content:
+          "Aplicamos medidas técnicas y administrativas razonables para proteger la información frente a accesos no autorizados.",
+      },
+      {
+        title: "4. Derechos",
+        content:
+          "El usuario puede solicitar revisión, corrección o eliminación de datos conforme a la normativa aplicable.",
+      },
+    ],
+  },
+  {
+    slug: "catalogo",
+    title: "Política de Privacidad — Catálogo",
+    subtitle: "Vitrina de productos, carrito y flujo de pedidos en línea.",
+    sections: [
+      {
+        title: "1. Datos que tratamos",
+        content:
+          "Tratamos datos de pedido, productos seleccionados, contacto y dirección de entrega cuando aplica, para procesar solicitudes.",
+      },
+      {
+        title: "2. Finalidad",
+        content:
+          "Utilizamos la información para confirmar pedidos, coordinar entrega o recolección, y mejorar la experiencia de compra.",
+      },
+      {
+        title: "3. Compartición",
+        content:
+          "Podemos compartir datos mínimos necesarios con pasarelas de pago o servicios logísticos, únicamente para completar el pedido.",
+      },
+      {
+        title: "4. Derechos",
+        content:
+          "Las personas usuarias pueden ejercer sus derechos de acceso, rectificación, cancelación u oposición por canales oficiales.",
+      },
+    ],
+  },
+];


### PR DESCRIPTION
### Motivation
- Actualizar la presentación legacy de paquetes a una vitrina moderna de proyectos terminados para mostrar los productos Ravekh de forma clara y coherente con la landing actual.
- Exponer accesos directos desde el menú y el footer para facilitar la navegación a la sección de proyectos y a las políticas de privacidad por producto.

### Description
- Añade el componente `ProjectsShowcase` y estilos (`src/new/systems/landing-ravekh/Projects/pages/ProjectsShowcase.tsx` y `.../styles/ProjectsShowcase.css`) e lo integra en la landing (`LandingRavekhPage`).
- Implementa el módulo de políticas con datos y slugs en `src/new/systems/legal/pages/privacyPolicies.ts` y las vistas `PrivacyPoliciesIndexPage.tsx` y `PrivacyPolicyPage.tsx` para `/politicas` y `/politicas/:policySlug`.
- Integra rutas nuevas en el router moderno (`src/new/routing/NewAppRoutes.tsx`) y agrega enlaces de acceso rápido en el footer (`src/new/systems/landing-ravekh/Footer/pages/Footer.tsx`) y en el menú flotante de la landing, además de estilos para el botón de menú (`LandingPage.css`).
- Añade scroll interno desde el menú flotante hacia la sección `#proyectos` y mantiene el estilo visual alineado con la landing existente.

### Testing
- Ejecutado `npm run build` y la compilación de Vite finalizó correctamente.
- Ejecutado `npm run test` y todos los tests automáticos incluidos en la suite moderna pasaron (informes de tests: todas las pruebas listadas pasaron).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d017794b6c83249d1e41c9c4aebff4)