### PR TITLE
Add dynamic catalog share metadata

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,7 @@
+[functions]
+  included_files = ["dist/index.html", "index.html"]
+
+[[headers]]
+  for = "/.well-known/apple-app-site-association"
+  [headers.values]
+    Content-Type = "application/json"

--- a/netlify/functions/catalog-meta.mjs
+++ b/netlify/functions/catalog-meta.mjs
@@ -1,0 +1,153 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+const DEFAULT_TITLE = "Catálogo digital | Ravekh";
+const DEFAULT_DESCRIPTION = "Explora productos, revisa detalles y realiza pedidos desde el catálogo digital de Ravekh.";
+const DEFAULT_IMAGE_PATH = "/ravekh.png";
+
+const normalizeBase = (value = "") => {
+  const trimmed = String(value).trim();
+  if (!trimmed) return "";
+  return trimmed.endsWith("/") ? trimmed : `${trimmed}/`;
+};
+
+const escapeHtml = (value = "") => String(value)
+  .replace(/&/g, "&amp;")
+  .replace(/</g, "&lt;")
+  .replace(/>/g, "&gt;")
+  .replace(/"/g, "&quot;")
+  .replace(/'/g, "&#39;");
+
+const isAbsoluteUrl = (value = "") => /^https?:\/\//i.test(value);
+
+const toAbsoluteUrl = (value, origin) => {
+  const trimmed = String(value ?? "").trim();
+  if (!trimmed) return `${origin}${DEFAULT_IMAGE_PATH}`;
+  if (isAbsoluteUrl(trimmed)) return trimmed;
+  return new URL(trimmed.startsWith("/") ? trimmed : `/${trimmed}`, origin).toString();
+};
+
+const getOrigin = (event) => {
+  try {
+    return new URL(event.rawUrl).origin;
+  } catch {
+    const host = event.headers.host || "ravekh.com";
+    const proto = event.headers["x-forwarded-proto"] || "https";
+    return `${proto}://${host}`;
+  }
+};
+
+const getCanonicalUrl = (event, origin) => {
+  try {
+    const url = new URL(event.rawUrl);
+    return `${origin}${url.pathname}`;
+  } catch {
+    return origin;
+  }
+};
+
+const readIndexHtml = async () => {
+  const candidates = [
+    path.join(process.cwd(), "dist", "index.html"),
+    path.join(process.cwd(), "index.html"),
+  ];
+
+  for (const candidate of candidates) {
+    try {
+      return await readFile(candidate, "utf8");
+    } catch {
+      // Try the next known location used by local builds and Netlify deploys.
+    }
+  }
+
+  throw new Error("No se encontró index.html para inyectar metadata del catálogo.");
+};
+
+const fetchBusiness = async (businessId) => {
+  const baseUrl = normalizeBase(process.env.VITE_API_URL || process.env.API_URL || "");
+  if (!baseUrl || !businessId) return null;
+
+  const response = await fetch(`${baseUrl}business/${encodeURIComponent(businessId)}`, {
+    headers: { Accept: "application/json" },
+  });
+
+  if (!response.ok) return null;
+  return response.json();
+};
+
+const buildCatalogSeo = (business, canonicalUrl, origin) => {
+  const name = String(business?.Name ?? business?.name ?? "").trim();
+  const logo = String(business?.Logo ?? business?.logo ?? "").trim();
+  const phone = String(business?.PhoneNumber ?? business?.phone ?? "").trim();
+  const businessName = name || "Catálogo digital";
+  const title = name ? `${businessName} | Catálogo digital` : DEFAULT_TITLE;
+  const description = name
+    ? (phone
+      ? `Explora el catálogo digital de ${businessName} y realiza tu pedido. Teléfono: ${phone}.`
+      : `Explora el catálogo digital de ${businessName} y realiza tu pedido en línea.`)
+    : DEFAULT_DESCRIPTION;
+  const image = toAbsoluteUrl(logo || DEFAULT_IMAGE_PATH, origin);
+
+  return { title, description, image, canonicalUrl };
+};
+
+const injectSeo = (html, seo) => {
+  const safeTitle = escapeHtml(seo.title || DEFAULT_TITLE);
+  const safeDescription = escapeHtml(seo.description || DEFAULT_DESCRIPTION);
+  const safeImage = escapeHtml(seo.image);
+  const safeUrl = escapeHtml(seo.canonicalUrl);
+
+  const cleaned = html
+    .replace(/<title>[\s\S]*?<\/title>/i, "")
+    .replace(/<meta\s+(?:name|property)=["'](?:description|robots|og:[^"']+|twitter:[^"']+)["'][^>]*>\s*/gi, "")
+    .replace(/<link\s+rel=["']canonical["'][^>]*>\s*/gi, "");
+
+  const tags = `
+  <title>${safeTitle}</title>
+  <meta name="description" content="${safeDescription}">
+  <meta name="robots" content="index,follow,max-image-preview:large">
+  <link rel="canonical" href="${safeUrl}">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Ravekh">
+  <meta property="og:url" content="${safeUrl}">
+  <meta property="og:title" content="${safeTitle}">
+  <meta property="og:description" content="${safeDescription}">
+  <meta property="og:image" content="${safeImage}">
+  <meta property="og:image:secure_url" content="${safeImage}">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="${safeTitle}">
+  <meta name="twitter:description" content="${safeDescription}">
+  <meta name="twitter:image" content="${safeImage}">
+`;
+
+  return cleaned.replace(/<\/head>/i, `${tags}</head>`);
+};
+
+export const handler = async (event) => {
+  const businessId = String(event.queryStringParameters?.id ?? "").trim();
+  const origin = getOrigin(event);
+  const canonicalUrl = getCanonicalUrl(event, origin);
+
+  try {
+    const [html, business] = await Promise.all([
+      readIndexHtml(),
+      fetchBusiness(businessId).catch(() => null),
+    ]);
+    const seo = buildCatalogSeo(business, canonicalUrl, origin);
+
+    return {
+      statusCode: 200,
+      headers: {
+        "Content-Type": "text/html; charset=utf-8",
+        "Cache-Control": "public, max-age=300, s-maxage=900, stale-while-revalidate=86400",
+      },
+      body: injectSeo(html, seo),
+    };
+  } catch (error) {
+    return {
+      statusCode: 500,
+      headers: { "Content-Type": "text/plain; charset=utf-8" },
+      body: error instanceof Error ? error.message : "Error generando metadata del catálogo.",
+    };
+  }
+};

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,2 +1,4 @@
 /.well-known/apple-app-site-association  /.well-known/apple-app-site-association  200
+/v2/catalogo/:id  /.netlify/functions/catalog-meta?id=:id  200
+/catalogo/:id  /.netlify/functions/catalog-meta?id=:id  200
 /*  /index.html  200

--- a/src/new/systems/catalog/storefront/ui/CatalogStorefrontPage.tsx
+++ b/src/new/systems/catalog/storefront/ui/CatalogStorefrontPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
+import { Helmet } from "react-helmet-async";
 import { FiSearch, FiShoppingCart, FiSliders, FiX } from "react-icons/fi";
 import { getPosApiBaseUrl } from "../../../pos/shared/config/posEnv";
 import { CatalogStorefrontApi, StorefrontCategory, StorefrontProductExtra, StorefrontVariant } from "../api/CatalogStorefrontApi";
@@ -412,8 +413,40 @@ export const CatalogStorefrontPage = () => {
     window.scrollTo({ top: 0, behavior: "smooth" });
   };
 
+  const catalogSeo = useMemo(() => {
+    const origin = typeof window !== "undefined" ? window.location.origin : "";
+    const canonicalUrl = typeof window !== "undefined" ? `${origin}/v2/catalogo/${businessId ?? ""}` : `/v2/catalogo/${businessId ?? ""}`;
+    const storeName = store?.name?.trim() || "Catálogo digital";
+    const title = store?.name ? `${storeName} | Catálogo digital` : "Catálogo digital | Ravekh";
+    const description = store?.phone
+      ? `Explora el catálogo digital de ${storeName} y realiza tu pedido. Teléfono: ${store.phone}.`
+      : `Explora el catálogo digital de ${storeName} y realiza tu pedido en línea.`;
+    const image = store?.logo
+      ? (store.logo.startsWith("http") ? store.logo : `${origin}${store.logo.startsWith("/") ? store.logo : `/${store.logo}`}`)
+      : `${origin}/ravekh.png`;
+
+    return { canonicalUrl, description, image, title };
+  }, [businessId, store]);
+
   return (
-    <main className="catalog-v2">
+    <>
+      <Helmet>
+        <title>{catalogSeo.title}</title>
+        <meta name="description" content={catalogSeo.description} />
+        <link rel="canonical" href={catalogSeo.canonicalUrl} />
+        <meta property="og:type" content="website" />
+        <meta property="og:site_name" content="Ravekh" />
+        <meta property="og:title" content={catalogSeo.title} />
+        <meta property="og:description" content={catalogSeo.description} />
+        <meta property="og:url" content={catalogSeo.canonicalUrl} />
+        <meta property="og:image" content={catalogSeo.image} />
+        <meta property="og:image:secure_url" content={catalogSeo.image} />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={catalogSeo.title} />
+        <meta name="twitter:description" content={catalogSeo.description} />
+        <meta name="twitter:image" content={catalogSeo.image} />
+      </Helmet>
+      <main className="catalog-v2">
       <header className="catalog-v2__header">
         <div className="catalog-v2__brand">
           <span className="catalog-v2__logo-sphere" aria-hidden={!store?.logo}>
@@ -626,6 +659,7 @@ export const CatalogStorefrontPage = () => {
           Ver carrito ({totalItems}) · {totalLabel}
         </Link>
       ) : null}
-    </main>
+      </main>
+    </>
   );
 };


### PR DESCRIPTION
### Motivation
- Allow catalog share links (e.g. `/v2/catalogo/227`) to show the business information and logo in link previews instead of the Ravekh corporate image. 

### Description
- Added a Netlify Function `netlify/functions/catalog-meta.mjs` that fetches business data from the API and injects server-rendered Open Graph/Twitter metadata (title, description, canonical and `og:image`) into `index.html` before replying. 
- Routed catalog URLs through the function by updating `public/_redirects` so `/v2/catalogo/:id` and legacy `/catalogo/:id` are served by the metadata function prior to the SPA fallback. 
- Included `dist/index.html`/`index.html` in `netlify.toml` so the function can read the built HTML for injection. 
- Added client-side metadata synchronization in the SPA using `react-helmet-async` in `src/new/systems/catalog/storefront/ui/CatalogStorefrontPage.tsx` to keep `title`, `description`, `canonical` and `og:image` updated after the business loads.

### Testing
- Ran a production build with `npm run build` which completed successfully. 
- Ran lint with `npm run lint` which failed due to preexisting unrelated lint errors in other files (`FormInput.jsx`, QRCode files and `tailwind.config.js`). 
- Ran the test suite with `npm test` which failed due to an existing assertion in the integration tests after `PASS unit-products-service`. 
- Executed Netlify function smoke tests using `node --input-type=module` against the new handler which returned `200` and injected `og:image` and `title` correctly, and a mocked `VITE_API_URL` invocation which returned business-specific `title` and `og:image` as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a1f6f99248324b5910e7382537bba)